### PR TITLE
Add CodeOwners.MD Example

### DIFF
--- a/github/CODEOWNERS.MD
+++ b/github/CODEOWNERS.MD
@@ -1,0 +1,40 @@
+# Copied from https://help.github.com/articles/about-codeowners/
+# Visual Example https://blog.github.com/2017-07-06-introducing-code-owners/
+
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @global-owner1 @global-owner2
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+*.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+*.go docs@example.com
+
+# In this example, @doctocat owns any files in the build/logs
+# directory at the root of the repository and any of its
+# subdirectories.
+/build/logs/ @doctocat
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository.
+/docs/ @doctocat


### PR DESCRIPTION
Something I think has a lot of value, adds people as auto reviewer. It's something I've been experiencing in other repos I've contributed to at work and personally. Trying to contribute back downstream as an alumnus 😄. Maybe we'd set up teams. @cuappdev/developers could have child teams like @cuappdev/tcat-dev for example that could be CODEOWNERS for a tcat repo.

I think GitHub teams is an underused feature with discussions and repo permissions ext. in general.

Hope all is well on the hill. Do NOT hesitate to reach out if you need me for anything.